### PR TITLE
refactor: Move api calls to facade

### DIFF
--- a/schedulerApp/frontend/src/App.js
+++ b/schedulerApp/frontend/src/App.js
@@ -5,71 +5,24 @@ import Login from './Pages/Login/Login'
 import Header from './Pages/Home/Header/Header'
 import Footer from './Pages/Home/Fotter/Footer';
 import Dashboard from './Pages/Profile/Dashboard/Dashboard'
-import { useState, useEffect } from 'react';
-import axios from 'axios';
 import ScheduleForm from './Pages/Scheduler/ScheduleForm';
 import ScheduleList from './Pages/ListSchedule/ListSchedule';
-import { UserProvider } from './UserProvider';
 
-axios.defaults.xsrfCookieName = 'csrftoken';
-axios.defaults.xsrfHeaderName = 'X-CSRFToken';
-axios.defaults.withCredentials = true;
-
-const client = axios.create({
-  baseURL: "http://localhost:8000"
-});
 function App() {
-  const [userData, setUserData] = useState(null);
-  const [loading, setLoading] = useState(true);
-
-  const fetchUserData = () => {
-
-    const cookies = document.cookie.split('; ').reduce((cookieObject, cookie) => {
-      const [name, value] = cookie.split('=');
-      cookieObject[name] = value;
-      return cookieObject;
-    }, {});
-    
-    console.log("Running app to fetch user data: ", cookies, cookies.jwt);
-
-    client.get("/api/user", 
-    {
-      withCredentials: true
-    })
-      .then(function (res) {
-        if (res.data && res.data.email) {
-          setUserData(res.data);
-          console.log("logado", res.data);
-        } else {
-          setUserData(res.data);
-        }
-      })
-      .catch(function (error) {
-        setUserData(null);
-      }).finally(() => {
-        setLoading(false);
-      });
-  };
-
-  useEffect(() => {
-    fetchUserData();
-  }, []); // Only run once on component mount
 
   return (
-    <UserProvider>
       <Router>
-        <Header loading={loading} userData={userData} />
+        <Header />
         <Routes>
           <Route path="/" element = {<Home />} />
           <Route path="/home" element = {<Home  />} />
-          <Route path="/login" element = {<Login userData={userData} setUserData={setUserData} />} />
-          <Route path="/profile" element = {<Dashboard  userData={userData} setUserData={setUserData} />} />
-          <Route path="/agenda" element = {<ScheduleForm userData={userData}  />} />
-          <Route path="/listar-agenda" element = {<ScheduleList userData={userData}  />} />
+          <Route path="/login" element = {<Login />} />
+          <Route path="/profile" element = {<Dashboard  />} />
+          <Route path="/agenda" element = {<ScheduleForm />} />
+          <Route path="/listar-agenda" element = {<ScheduleList />} />
         </Routes>
         <Footer/>
       </Router>
-    </UserProvider>
   );
 }
 

--- a/schedulerApp/frontend/src/App.js
+++ b/schedulerApp/frontend/src/App.js
@@ -9,6 +9,7 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import ScheduleForm from './Pages/Scheduler/ScheduleForm';
 import ScheduleList from './Pages/ListSchedule/ListSchedule';
+import { UserProvider } from './UserProvider';
 
 axios.defaults.xsrfCookieName = 'csrftoken';
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
@@ -55,18 +56,20 @@ function App() {
   }, []); // Only run once on component mount
 
   return (
-    <Router>
-      <Header loading={loading} userData={userData} />
-      <Routes>
-        <Route path="/" element = {<Home />} />
-        <Route path="/home" element = {<Home  />} />
-        <Route path="/login" element = {<Login userData={userData} setUserData={setUserData} />} />
-        <Route path="/profile" element = {<Dashboard  userData={userData} setUserData={setUserData} />} />
-        <Route path="/agenda" element = {<ScheduleForm userData={userData}  />} />
-        <Route path="/listar-agenda" element = {<ScheduleList userData={userData}  />} />
-      </Routes>
-      <Footer/>
-    </Router>
+    <UserProvider>
+      <Router>
+        <Header loading={loading} userData={userData} />
+        <Routes>
+          <Route path="/" element = {<Home />} />
+          <Route path="/home" element = {<Home  />} />
+          <Route path="/login" element = {<Login userData={userData} setUserData={setUserData} />} />
+          <Route path="/profile" element = {<Dashboard  userData={userData} setUserData={setUserData} />} />
+          <Route path="/agenda" element = {<ScheduleForm userData={userData}  />} />
+          <Route path="/listar-agenda" element = {<ScheduleList userData={userData}  />} />
+        </Routes>
+        <Footer/>
+      </Router>
+    </UserProvider>
   );
 }
 

--- a/schedulerApp/frontend/src/Pages/Home/Header/Header.js
+++ b/schedulerApp/frontend/src/Pages/Home/Header/Header.js
@@ -4,10 +4,12 @@ import { Link } from 'react-router-dom';
 import logo from '../../../Images/logo ic.png';
 import './Header.css';
 import { useEffect } from 'react';
+import { useUser } from './../../../UserProvider';
 
-const Header = ({loading, userData}) => {
+const Header = ({loading}) => {
+  const { userData, getUser } = useUser();
   useEffect(() => {
-    console.log('userData has changed at header:', userData, loading);
+    console.log("header tenta dar get user");
   }, [userData, loading]);
 
   return (

--- a/schedulerApp/frontend/src/Pages/ListSchedule/ListSchedule.js
+++ b/schedulerApp/frontend/src/Pages/ListSchedule/ListSchedule.js
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import Calendar from 'react-calendar'; // Example calendar library, you can choose the one that fits your needs
-import Datetime from 'react-datetime';
 import 'react-datetime/css/react-datetime.css';
 import './ListSchedule.css';
+import { useUser } from './../../UserProvider';
 
 axios.defaults.xsrfCookieName = 'csrftoken';
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
@@ -13,7 +13,8 @@ const client = axios.create({
   baseURL: "http://localhost:8000"
 });
 
-const ScheduleList = ({ userData }) => {
+const ScheduleList = () => {
+  const { userData, getUser } = useUser();
   const [schedules, setSchedules] = useState([]);
   const [loading, setLoading] = useState(true);
   const [closestEventDate, setClosestEventDate] = useState(null);
@@ -42,22 +43,16 @@ const ScheduleList = ({ userData }) => {
   };
 
   useEffect(() => {
-    client.get("/api/user", 
-    {
-      withCredentials: true
-    })
-      .then(function (res) {
-        if (res.data && res.data.email) {
-          user_id = res.data.user_id;
-          console.log("conseguiu logar", res.data);
-          console.log("user_id: ", user_id);
-        }
-      })
-      .catch(function (error) {
-        console.log("nao conseguiu o id do usuario");
-      }).finally(function () {
-        fetchSchedules(user_id);
-    });
+    const fetchData = async () => {
+      await getUser();
+      if (userData) {
+        user_id = userData.user_id;
+      }
+      setLoading(false);
+      console.log("user_id: ", user_id);
+     fetchSchedules(user_id);  
+    };
+    fetchData();
   }, []);
 
   const fetchSchedules = (user_id) => {

--- a/schedulerApp/frontend/src/Pages/Login/Login.js
+++ b/schedulerApp/frontend/src/Pages/Login/Login.js
@@ -5,49 +5,20 @@ import Container from 'react-bootstrap/Container';
 import Navbar from 'react-bootstrap/Navbar';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
+import { useUser } from './../../UserProvider';
 
 
-axios.defaults.xsrfCookieName = 'csrftoken';
-axios.defaults.xsrfHeaderName = 'X-CSRFToken';
-axios.defaults.withCredentials = true;
+const Login = () => {
+    const { userData, getUser, loginUser, registerUser, logoutUser } = useUser();
 
-const client = axios.create({
-  baseURL: "http://localhost:8000"
-});
-
-const Login = ({userData, setUserData}) => {
     const [registrationToggle, setRegistrationToggle] = useState(false);
     const [email, setEmail] = useState('');
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
 
     useEffect(() => {
-      const cookies = document.cookie.split('; ').reduce((cookieObject, cookie) => {
-        const [name, value] = cookie.split('=');
-        cookieObject[name] = value;
-        return cookieObject;
-      }, {});
-      
-
-      console.log("Login: ", cookies, cookies.jwt);
-
-      client.get("/api/user", 
-      {
-        withCredentials: true
-      })
-        .then(function (res) {
-          if (res.data && res.data.email) {
-            setUserData(res.data);
-            console.log("logado", res.data);
-          } else {
-            setUserData(res.data);
-          }
-        })
-        .catch(function (error) {
-          setUserData(null);
-        });
+      getUser();
     }, []);
-    
 
     function update_form_btn() {
         if (registrationToggle) {
@@ -61,58 +32,27 @@ const Login = ({userData, setUserData}) => {
 
     function submitRegistration(e) {
         e.preventDefault();
-        client.post(
-        "/api/register",
-        {
-            email: email,
-            username: username,
-            password: password
-        }
-        ).then(function(res) {
-        client.post(
-            "/api/login",
-            {
-            email: email,
-            password: password
-            }
-        ).then(function(res) {
-          console.log(res.data);
-          setUserData(res.data);
-          const token = res.data.jwt
-          document.cookie = `jwt=${token}; path=/`;
-        }).catch(function(error){
-          console.log("Error");
-        });
-        });
+        const userCredentials = {
+          email: email,
+          username: username,
+          password: password,
+        };
+        registerUser(userCredentials);
     }
 
     function submitLogin(e) {
         e.preventDefault();
-        client.post(
-        "/api/login",
-        {
-            email: email,
-            password: password
-        }
-        ).then(function(res) {
-          console.log(res.data);
-          setUserData(res.data);
-          const token = res.data.jwt
-          document.cookie = `jwt=${token}; path=/`;
-        }).catch(function(error){
-          console.log("Error on login.");
-          console.log(error);
-        });
+        const userCredentials = {
+          email: email,
+          password: password,
+        };
+        console.log(userCredentials);
+        loginUser(userCredentials);
     }
 
     function submitLogout(e) {
         e.preventDefault();
-        client.post(
-        "/api/logout",
-        {withCredentials: true}
-        ).then(function(res) {
-          setUserData(null);
-        });
+        logoutUser();
     }
 
   if (userData) {
@@ -143,9 +83,9 @@ const Login = ({userData, setUserData}) => {
     <Navbar bg="dark" variant="dark">
       <Container>
         <Navbar.Brand>Faça seu login</Navbar.Brand>
-        <form onSubmit={e => submitLogout(e)}>
+        {/* <form onSubmit={e => submitLogout(e)}>
                   <Button type="submit" variant="light">Log out</Button>
-                </form>
+                </form> */}
         <Navbar.Toggle />
         <Navbar.Collapse className="justify-content-end">
           <Navbar.Text>

--- a/schedulerApp/frontend/src/Pages/Profile/Dashboard/Dashboard.js
+++ b/schedulerApp/frontend/src/Pages/Profile/Dashboard/Dashboard.js
@@ -1,60 +1,21 @@
 import React from 'react';
-import axios from 'axios';
 import { Link } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
+import { useUser } from './../../../UserProvider';
 
-
-axios.defaults.xsrfCookieName = 'csrftoken';
-axios.defaults.xsrfHeaderName = 'X-CSRFToken';
-axios.defaults.withCredentials = true;
-
-const client = axios.create({
-  baseURL: "http://localhost:8000"
-});
-
-const Dashboard = ({userData, setUserData}) => {
-
-
-  const fetchUserData = () => {
-
-    const cookies = document.cookie.split('; ').reduce((cookieObject, cookie) => {
-      const [name, value] = cookie.split('=');
-      cookieObject[name] = value;
-      return cookieObject;
-    }, {});
-    
-    console.log("Running app to fetch user data: ", cookies, cookies.jwt);
-
-    client.get("/api/user", 
-    {
-      withCredentials: true
-    })
-      .then(function (res) {
-        if (res.data && res.data.email) {
-          setUserData(res.data);
-          console.log("logado", res.data);
-        } else {
-          setUserData(res.data);
-        }
-      })
-      .catch(function (error) {
-        setUserData(null);
-      });
-  };
+const Dashboard = () => {
+  const { userData, getUser, logoutUser } = useUser();
 
   useEffect(() => {
-    fetchUserData();
-  }, []); // Only run once on component mount
+    getUser();
+  }, []); 
   
   function submitLogout(e) {
-        e.preventDefault();
-        client.post(
-        "/api/logout",
-        {withCredentials: true}
-        ).then(function(res) {
-            setUserData(null);
-        });
-    }
+    e.preventDefault();
+    console.log("dashboard tenta dar logout");
+    logoutUser();
+    console.log(userData);
+  }
 
   return (
     <div>

--- a/schedulerApp/frontend/src/Pages/Scheduler/ScheduleForm.js
+++ b/schedulerApp/frontend/src/Pages/Scheduler/ScheduleForm.js
@@ -21,7 +21,7 @@ const ScheduleForm = ({userData}) => {
   });
 
   var user_id = null;
-  useEffect(() => {
+  const getUserId = () => {
     client.get("/api/user", 
     {
       withCredentials: true
@@ -35,8 +35,9 @@ const ScheduleForm = ({userData}) => {
       .catch(function (error) {
         console.log("nao conseguiu o id do usuario");
       });
+    return user_id;
+  };
 
-  }, []);
 
   const handleChange = (name, value) => {
     setFormData({
@@ -51,6 +52,7 @@ const ScheduleForm = ({userData}) => {
   const handleSubmit = (e) => {
     e.preventDefault();
     // Handle form submission logic here
+    getUserId();
     console.log('Form data submitted:', formData);
     const requestData = {
       start_ts: dateToString(formData.start_time),

--- a/schedulerApp/frontend/src/Pages/Scheduler/ScheduleForm.js
+++ b/schedulerApp/frontend/src/Pages/Scheduler/ScheduleForm.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import Datetime from 'react-datetime';
 import 'react-datetime/css/react-datetime.css';
+import { useUser } from './../../UserProvider';
 import axios from 'axios';
-
 
 axios.defaults.xsrfCookieName = 'csrftoken';
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
@@ -12,7 +12,8 @@ const client = axios.create({
   baseURL: "http://localhost:8000"
 });
 
-const ScheduleForm = ({userData}) => {
+const ScheduleForm = () => {
+  const { userData, getUser } = useUser();
   const [successMessage, setSuccessMessage] = useState(null);
   const [errorMessage, setErrorMessage] = useState(null);
   const [formData, setFormData] = useState({
@@ -22,19 +23,9 @@ const ScheduleForm = ({userData}) => {
 
   var user_id = null;
   const getUserId = () => {
-    client.get("/api/user", 
-    {
-      withCredentials: true
-    })
-      .then(function (res) {
-        if (res.data && res.data.email) {
-          user_id = res.data.user_id;
-          console.log("conseguiu logar", res.data);
-        }
-      })
-      .catch(function (error) {
-        console.log("nao conseguiu o id do usuario");
-      });
+    getUser();
+    if(userData)
+      user_id = userData.user_id;
     return user_id;
   };
 

--- a/schedulerApp/frontend/src/UserProvider.js
+++ b/schedulerApp/frontend/src/UserProvider.js
@@ -1,0 +1,107 @@
+import React, { createContext, useContext, useState } from 'react';
+import axios from 'axios';
+
+axios.defaults.xsrfCookieName = 'csrftoken';
+axios.defaults.xsrfHeaderName = 'X-CSRFToken';
+axios.defaults.withCredentials = true;
+
+const client = axios.create({
+  baseURL: "http://localhost:8000"
+});
+
+
+const UserContext = createContext();
+
+export const UserProvider = ({children}) => {
+    const [userData, setUserData] = useState(null);
+
+    const updateUserData = (newData) => {
+        setUserData(newData);
+    };
+
+    const getUser = () => {
+        client.get("/api/user", 
+        {
+          withCredentials: true
+        })
+          .then(function (res) {
+            if (res.data && res.data.email) {
+              console.log("conseguiu logar", res.data);
+              updateUserData(res.data);
+            }
+          })
+          .catch(function (error) {
+            console.log("nao conseguiu o id do usuario");
+          });
+      return userData;
+    };
+    const loginUser = ({email, password}) => {
+      console.log("tentando logar: ", email, password)
+        client.post("/api/login", {
+            email: email,
+            password: password
+        }, {
+            withCredentials: true
+        })
+        .then(function (res) {
+          console.log(res.status);
+          console.log("cheguei aqui: ", res.data);
+            if (res.status == 200) {
+                console.log("conseguiu logar", res.data);
+                updateUserData(res.data);
+            }
+        })
+        .catch(function (error) {
+            console.log("nao conseguiu logar");
+        });
+    }
+    const logoutUser = () => {
+        client.post("/api/logout", {}, {
+            withCredentials: true
+        })
+        .then(function (res) {
+            if (res.status === 204 || res.status==200) {
+                console.log("conseguiu deslogar");
+                updateUserData(null);
+              }
+        })
+        .catch(function (error) {
+            console.log("nao conseguiu deslogar");
+        });
+    }
+    const registerUser = ({email, username, password}) => {
+        client.post(
+            "/api/register",
+            {
+                email: email,
+                username: username,
+                password: password
+            }
+            ).then(function(res) {
+            client.post(
+                "/api/login",
+                {
+                email: email,
+                password: password
+                }
+            ).then(function(res) {
+              console.log(res.data);
+              setUserData(res.data);
+              const token = res.data.jwt
+              document.cookie = `jwt=${token}; path=/`;
+            }).catch(function(error){
+              console.log("Error");
+            });
+        });
+    }
+    
+    return (
+        <UserContext.Provider value={{ userData, getUser, loginUser, registerUser, logoutUser }}>
+          {children}
+        </UserContext.Provider>
+      );
+};
+
+export const useUser = () => {
+    return useContext(UserContext);
+};  

--- a/schedulerApp/frontend/src/index.js
+++ b/schedulerApp/frontend/src/index.js
@@ -4,11 +4,14 @@ import 'bootstrap/dist/css/bootstrap.css';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { UserProvider } from './UserProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <UserProvider>
+      <App />
+    </UserProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
Movemos todas as chamadas a API de usario a um "userProvider" que serve como o design Pattern Facade.
Devemos fazer o mesmo depois para os outros tipos de chamada de API.
Isso também resolve um code smell do tipo [change preventer](https://refactoring.guru/pt-br/refactoring/smells/change-preventers), porque teríamos que fazer um [shotgun surgery](https://refactoring.guru/pt-br/smells/shotgun-surgery) para, por exemplo, mudar o endpoint da API.